### PR TITLE
Rename github to github1

### DIFF
--- a/reponames/github
+++ b/reponames/github
@@ -1,6 +1,0 @@
-excalibur1234/pacui
-puxplaying/autogit
-puxplaying/manjaro-update
-puxplaying/toolbox
-puxplaying/mutter-x11-scaling
-puxplaying/gnome-software-snap

--- a/reponames/github1
+++ b/reponames/github1
@@ -1,0 +1,6 @@
+excalibur1234/pacui
+puxplaying/autogit
+puxplaying/manjaro-update
+puxplaying/toolbox
+puxplaying/mutter-x11-scaling
+puxplaying/gnome-software-snap


### PR DESCRIPTION
This fixes the new fzf menu finding source files in the first github repo.
Don't use github as filename for the first repo but instead github1 etc. Otherwise the search doesn't work as it finds too many matches of the ..SOURCES in the config.